### PR TITLE
Fix checksums again

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -8,9 +8,9 @@ pkgbase = dropbox-cli
 	license = GPL
 	depends = dropbox
 	depends = python-gobject
-	source = dropbox-cli-2020.03.04.py::https://linux.dropbox.com/packages/dropbox.py
+	source = dropbox-cli-2020.03.04.py::https://www.dropbox.com/download?dl=packages/dropbox.py
 	source = dropboxd-fallback.patch
-	sha256sums = e8fecc095561bf4a30a9889e25c3afa40c01e1554f3392a3b949b02ee1cf19ca
-	sha256sums = 9ae702ebf0699ac56fbf99c577ddaf22701dfd1c9e40d6ec5ac56475c2636f48
+	sha256sums = 7889ce1d872bce85b3e94b929abacd6086e7f378644519fd8ebd8acf0316e59f
+	sha256sums = fb862b534730f0765b4317ca5d0816f42d5a4be0018004c5b18fde63524fdb14
 
 pkgname = dropbox-cli

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,12 +14,12 @@ license=("GPL")
 depends=("${pkgname%-cli}" "python-gobject")
 install="${pkgname}.install"
 source=(
-  "${pkgname}-${pkgver}.py::https://linux.${pkgname%-cli}.com/packages/${pkgname%-cli}.py"
+  "${pkgname}-${pkgver}.py::https://www.${pkgname%-cli}.com/download?dl=packages/${pkgname%-cli}.py"
   "${pkgname%-cli}d-fallback.patch"
 )
 sha256sums=(
-  "e8fecc095561bf4a30a9889e25c3afa40c01e1554f3392a3b949b02ee1cf19ca"
-  "9ae702ebf0699ac56fbf99c577ddaf22701dfd1c9e40d6ec5ac56475c2636f48"
+  "7889ce1d872bce85b3e94b929abacd6086e7f378644519fd8ebd8acf0316e59f"
+  "fb862b534730f0765b4317ca5d0816f42d5a4be0018004c5b18fde63524fdb14"
 )
 
 prepare() {

--- a/dropboxd-fallback.patch
+++ b/dropboxd-fallback.patch
@@ -1,8 +1,8 @@
 diff --git a/dropbox-cli.py b/dropbox-cli.py
-index c27131b..134836a 100644
+index 99830c3..5925761 100644
 --- a/dropbox-cli.py
 +++ b/dropbox-cli.py
-@@ -76,6 +76,12 @@ DROPBOX_DIST_PATH = "%s/.dropbox-dist" % PARENT_DIR
+@@ -74,6 +74,12 @@ DROPBOX_DIST_PATH = "%s/.dropbox-dist" % PARENT_DIR
  DROPBOXD_PATH = os.path.join(DROPBOX_DIST_PATH, "dropboxd")
  DESKTOP_FILE = "/usr/share/applications/dropbox.desktop"
  


### PR DESCRIPTION
The build failed on revision 79b1cda, and I needed to revert the checksums to successfully build the package.