### PR TITLE
fix: update sha256 for latest upstream release

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: carstene1ns <arch carsten-teibes de>
 
 pkgname=dropbox-cli
-pkgver=2024.1.22
+pkgver=2024.01.22
 pkgrel=1
 pkgdesc="Command line interface for Dropbox"
 arch=("any")

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,7 +18,7 @@ source=(
   "${pkgname%-cli}d-fallback.patch"
 )
 sha256sums=(
-  "a7334c5003287d6bc94c59bfbd9a9b2e9e82047c8b35732c739f8cb4ecfeedbc"
+  "33e4463fdd6f90cab355e2f6b951c90160d7a3620cca63e3a676457e01d368f0"
   "3e4f5d44c58dbeb586bb9539551ea1206e8a1e4b025ac316c42ba24c53c8f077"
 )
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: carstene1ns <arch carsten-teibes de>
 
 pkgname=dropbox-cli
-pkgver=2023.09.06
+pkgver=2024.1.22
 pkgrel=1
 pkgdesc="Command line interface for Dropbox"
 arch=("any")


### PR DESCRIPTION
It seems dropbox released a new vesion. The package is flagged on AUR but I thought I'd suggest the change here anyway, to try to help out a bit.

Obviously, you'll probably want to verify the SHA256 yourself, but no harm opening a PR, hopefully!